### PR TITLE
Add DL patches to support DLE testing

### DIFF
--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -419,7 +419,7 @@ try:
     class DefaultPluginManager(BuiltinPluginManager, EntryPointPluginManager):
         pass
 
-except ImportError:
+except ImportError, AttributeError:
     class DefaultPluginManager(BuiltinPluginManager):
         pass
 

--- a/nose/plugins/plugintest.py
+++ b/nose/plugins/plugintest.py
@@ -106,7 +106,14 @@ except ImportError:
 
 __all__ = ['PluginTester', 'run']
 
-from os import getpid
+try:
+    from os import getpid
+    # if we fail to import getpid, just return a 'static' ineger
+except ImportError:
+    import random
+    def getpid(rv=[random.randint(0, 9999999),]):
+        return rv[0]
+
 class MultiProcessFile(object):
     """
     helper for testing multiprocessing
@@ -173,7 +180,8 @@ class MultiProcessFile(object):
 try:
     from multiprocessing import Manager
     Buffer = MultiProcessFile
-except ImportError:
+    # IronPython raises a TypeError trying to import multiprocessing
+except (ImportError, TypeError):
     Buffer = StringIO
 
 class PluginTester(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ py3where=build/tests
 
 [bdist_rpm]
 doc_files = README.txt
-;; Uncomment if your platform automatically gzips man pages
-;; See README.BDIST_RPM
-;; install_script = install-rpm.sh
+
+[egg_info]
+tag_build =
+tag_date = 0
+tag_svn_revision = 0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-VERSION = '1.3.7'
+VERSION = '1.3.7+dl.1'
 py_vers_tag = '-%s.%s' % sys.version_info[:2]
 
 test_dirs = ['functional_tests', 'unit_tests', os.path.join('doc','doc_tests'), 'nose']


### PR DESCRIPTION
- These were obtained by diffing the nose-1.37-dl.zip file against the master of
  nose, and applying the resulting patches.

- These patches accomodate a lack of the getpid method, and differences in
  exception handling in IronPython.